### PR TITLE
Accept a Map directly

### DIFF
--- a/libs/Graph.js
+++ b/libs/Graph.js
@@ -1,6 +1,7 @@
 const Queue = require('./PriorityQueue');
 const removeDeepFromMap = require('./removeDeepFromMap');
 const toDeepMap = require('./toDeepMap');
+const validateDeep = require('./validateDeep');
 
 /** Creates and manages a graph */
 class Graph {
@@ -18,7 +19,10 @@ class Graph {
    *       },
    *     }
    *
-   * @param {Object} [graph] - Initial graph definition
+   * In alternative to an object, you can pass a `Map` of `Map`. This will
+   * allow you to specify numbers as keys.
+   *
+   * @param {Objec|Map} [graph] - Initial graph definition
    * @example
    *
    * const route = new Graph();
@@ -28,16 +32,39 @@ class Graph {
    *   A: { B: 1 },
    *   B: { A: 1, C: 2, D: 4 },
    * });
+   *
+   * // Passing a Map
+   * const g = new Map()
+   *
+   * const a = new Map()
+   * a.set('B', 1)
+   *
+   * const b = new Map()
+   * b.set('A', 1)
+   * b.set('C', 2)
+   * b.set('D', 4)
+   *
+   * g.set('A', a)
+   * g.set('B', b)
+   *
+   * const route = new Graph(g)
    */
   constructor(graph) {
-    this.graph = graph ? toDeepMap(graph) : new Map();
+    if (graph instanceof Map) {
+      validateDeep(graph);
+      this.graph = graph;
+    } else if (graph) {
+      this.graph = toDeepMap(graph);
+    } else {
+      this.graph = new Map();
+    }
   }
 
   /**
    * Adds a node to the graph
    *
    * @param {string} name      - Name of the node
-   * @param {Object} neighbors - Neighbouring nodes and cost to reach them
+   * @param {Object|Map} neighbors - Neighbouring nodes and cost to reach them
    * @return {this}
    * @example
    *
@@ -49,9 +76,24 @@ class Graph {
    * route
    *   .addNode('B', { A: 1 })
    *   .addNode('C', { A: 3 });
+   *
+   * // The neighbors can be expressed in a Map
+   * const d = new Map()
+   * d.set('A', 2)
+   * d.set('B', 8)
+   *
+   * route.addNode('D', d)
    */
   addNode(name, neighbors) {
-    this.graph.set(name, toDeepMap(neighbors));
+    let nodes;
+    if (neighbors instanceof Map) {
+      validateDeep(neighbors);
+      nodes = neighbors;
+    } else {
+      nodes = toDeepMap(neighbors);
+    }
+
+    this.graph.set(name, nodes);
 
     return this;
   }

--- a/libs/validateDeep.js
+++ b/libs/validateDeep.js
@@ -1,0 +1,23 @@
+/**
+ * Validate a map to ensure all it's values are either a number or a map
+ *
+ * @param {Map} map - Map to valiadte
+ */
+function validateDeep(map) {
+  if (!(map instanceof Map)) {
+    throw new Error(`Invalid graph: Expected Map instead found ${typeof map}`);
+  }
+
+  map.forEach((value, key) => {
+    if (typeof value === 'object' && value instanceof Map) {
+      validateDeep(value);
+      return;
+    }
+
+    if (typeof value !== 'number' || value <= 0) {
+      throw new Error(`Values must be numbers greater than 0. Found value ${value} at ${key}`);
+    }
+  });
+}
+
+module.exports = validateDeep;

--- a/test/Graph.test.js
+++ b/test/Graph.test.js
@@ -27,6 +27,30 @@ describe('Graph', () => {
       const a = route.graph.get('a');
       demand(a).be.instanceOf(Map);
     });
+
+    it('accepts a Map as graph', () => {
+      const graph = new Map();
+      const a = new Map();
+      a.set('b', 1);
+      a.set('c', 2);
+      graph.set('a', a);
+
+      const route = new Graph(graph);
+
+      demand(route.graph.size).equal(1);
+    });
+
+    it('accepts numbers as key when in a map', () => {
+      const graph = new Map();
+      const a = new Map();
+      a.set(1, 1);
+      a.set(2, 2);
+      graph.set(1, a);
+
+      const route = new Graph(graph);
+
+      demand(route.graph.size).equal(1);
+    });
   });
 
   describe('#addNode()', () => {
@@ -46,6 +70,21 @@ describe('Graph', () => {
       const graph = new Graph();
 
       demand(graph.addNode('a', { b: 10, c: 20 })).be.instanceOf(Graph);
+    });
+
+    it('accepts a map', () => {
+      const route = new Graph();
+      const a = new Map();
+      a.set('b', 10);
+      a.set('c', 20);
+
+      route.addNode('a', a);
+
+      const node = route.graph.get('a');
+
+      demand(node).be.instanceOf(Map);
+      demand(node.get('b')).equal(10);
+      demand(node.get('c')).equal(20);
     });
   });
 

--- a/test/validateDeep.test.js
+++ b/test/validateDeep.test.js
@@ -1,0 +1,57 @@
+/* eslint-env node, mocha */
+/* eslint import/no-extraneous-dependencies: ["error", {"devDependencies": true}] */
+
+require('must');
+const demand = require('must');
+
+const validateDeep = require('../libs/validateDeep');
+
+describe('validateDeep()', () => {
+  it('does nothing on a valid deep map', () => {
+    const m = new Map();
+    const a = new Map();
+    a.set('a', 1);
+    m.set('a', a);
+
+    validateDeep(m);
+  });
+
+  it('rejects non-number values', () => {
+    const m = new Map();
+    const a = new Map();
+    a.set('a', 'something');
+    m.set('a', a);
+
+    demand(validateDeep.bind(this, m))
+      .to.throw(Error, /must be numbers/);
+  });
+
+  it('rejects negative values', () => {
+    const m = new Map();
+    const a = new Map();
+    a.set('a', -3);
+    m.set('a', a);
+
+    demand(validateDeep.bind(this, m))
+      .to.throw(Error, /must be numbers/);
+  });
+
+  it('rejects 0', () => {
+    const m = new Map();
+    const a = new Map();
+    a.set('a', 0);
+    m.set('a', a);
+
+    demand(validateDeep.bind(this, m))
+      .to.throw(Error, /must be numbers/);
+  });
+
+  it('accepts 0.02', () => {
+    const m = new Map();
+    const a = new Map();
+    a.set('a', 0.02);
+    m.set('a', a);
+
+    validateDeep(m);
+  });
+});


### PR DESCRIPTION
Add support for massing directly a deep `Map` to the `Graph` constructor or to `addNode`.

Closes #11 