### PR TITLE
Add babelify transform when using browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "sinon": "^1.17.5",
     "vinyl-source-stream": "^1.1.0"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "browserify": {
+    "transform": ["babelify"]
+  }
 }


### PR DESCRIPTION
I see this module has `node` in the name, but it's also useful as a client-side Javascript implementation of Dijkstra's algorithm. As written, it runs great in Chrome out of the box when bundled with `browserify`, but the ES6 features throw errors in Safari and other browsers.

Per the  [babelify instructions](https://github.com/babel/babelify#faq), I can get Babel to transpile this module with just one extra  flag in the `package.json`. With this change, I can add the module to my browserify builds and run it in Safari without any trouble.

Since this change doesn't affect any core code, it should not effect anything if you're not using browserify.