### PR TITLE
Avoiding nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ route.removeNode('c');
   - `Boolean cost`, default `false`: If set to true, an object will be returned with the following keys:
     - `Array path`: Computed path (subject to other options)
     - `Number cost`: Total cost for the found path
+  - `Array avoid`, default `[]`: Nodes to be avoided
 
 #### Returns
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ route.removeNode('c');
 - `String start`: Name of the starting node
 - `String goal`: Name of out goal node
 - `Object options` _optional_: Addittional options:
-  - `Boolean trim`, deafult `false`: If set to true, the result won't include the start and goal nodes
+  - `Boolean trim`, default `false`: If set to true, the result won't include the start and goal nodes
   - `Boolean reverse`, default `false`: If set to true, the result will be in reverse order, from goal to start
   - `Boolean cost`, default `false`: If set to true, an object will be returned with the following keys:
     - `Array path`: Computed path (subject to other options)

--- a/libs/Graph.js
+++ b/libs/Graph.js
@@ -184,6 +184,9 @@ class Graph {
     let path = [];
     let totalCost = 0;
 
+    let avoid = [];
+    if (options.avoid && Array.isArray(options.avoid)) avoid = options.avoid;
+
     // Add the starting point to the frontier, it will be the first node visited
     frontier.set(start, 0);
 
@@ -213,8 +216,8 @@ class Graph {
       // Loop all the neighboring nodes
       const neighbors = this.graph.get(node.key) || new Map();
       neighbors.forEach((nCost, nNode) => {
-        // If we already explored the node, skip it
-        if (explored.has(nNode)) return null;
+        // If we already explored the node, or the node is to be avoided, skip it
+        if (explored.has(nNode) || avoid.includes(nNode)) return null;
 
         // If the neighboring node is not yet in the frontier, we add it with
         // the correct cost

--- a/libs/Graph.js
+++ b/libs/Graph.js
@@ -185,7 +185,13 @@ class Graph {
     let totalCost = 0;
 
     let avoid = [];
-    if (options.avoid && Array.isArray(options.avoid)) avoid = options.avoid;
+    if (options.avoid) avoid = [].concat(options.avoid);
+
+    if (avoid.includes(start)) {
+      throw new Error(`Starting node (${start}) cannot be avoided`);
+    } else if (avoid.includes(goal)) {
+      throw new Error(`Ending node (${goal}) cannot be avoided`);
+    }
 
     // Add the starting point to the frontier, it will be the first node visited
     frontier.set(start, 0);

--- a/test/Graph.test.js
+++ b/test/Graph.test.js
@@ -214,7 +214,7 @@ describe('Graph', () => {
       res.cost.must.equal(0);
     });
 
-    it('returns the same path regardless of whether a node which is not part of the calculated shortest path is avoided',
+    it('returns the same path if a node which is not part of the shortest path is avoided',
     () => {
       const route = new Graph({
         a: { b: 1 },
@@ -229,7 +229,7 @@ describe('Graph', () => {
       path.must.eql(path2);
     });
 
-    it('returns a different path if a node which is part of the calculated shortest path is avoided',
+    it('returns a different path if a node which is part of the shortest path is avoided',
     () => {
       const route = new Graph({
         a: { b: 1, c: 50 },
@@ -270,7 +270,7 @@ describe('Graph', () => {
       const res = route.path('a', 'c', { cost: true });
       const res2 = route.path('a', 'c', { avoid: ['z'], cost: true });
 
-      res.path.must.eql(res.path2);
+      res.path.must.eql(res2.path);
       res.cost.must.equal(res2.cost);
     });
 

--- a/test/Graph.test.js
+++ b/test/Graph.test.js
@@ -214,6 +214,66 @@ describe('Graph', () => {
       res.cost.must.equal(0);
     });
 
+    it('returns the same path regardless of whether a node which is not part of the calculated shortest path is avoided',
+    () => {
+      const route = new Graph({
+        a: { b: 1 },
+        b: { a: 1, c: 1 },
+        c: { b: 1, d: 1 },
+        d: { c: 1 },
+      });
+
+      const path = route.path('a', 'c', { cost: true });
+      const path2 = route.path('a', 'c', { avoid: ['d'], cost: true });
+
+      path.must.eql(path2);
+    });
+
+    it('returns a different path if a node which is part of the calculated shortest path is avoided',
+    () => {
+      const route = new Graph({
+        a: { b: 1, c: 50 },
+        b: { a: 1, c: 1 },
+        c: { a: 50, b: 1, d: 1 },
+        d: { c: 1 },
+      });
+
+      const res = route.path('a', 'd', { cost: true });
+      const res2 = route.path('a', 'd', { avoid: ['b'], cost: true });
+
+      res.path.must.not.eql(res.path2);
+      res.cost.must.be.at.most(res2.cost);
+    });
+
+    it('throws an error if the start node is avoided',
+    () => {
+      const route = new Graph(vertices);
+
+      const res = route.path('a', 'c', { avoid: ['a'] });
+
+      res.must.be.an.error(Error);
+    });
+
+    it('throws an error if the end node is avoided',
+    () => {
+      const route = new Graph(vertices);
+
+      const res = route.path('a', 'c', { avoid: ['c'] });
+
+      res.must.be.an.error(Error);
+    });
+
+    it('returns the same path and cost if a node which is not part of the graph is avoided',
+    () => {
+      const route = new Graph(vertices);
+
+      const res = route.path('a', 'c', { cost: true });
+      const res2 = route.path('a', 'c', { avoid: ['z'], cost: true });
+
+      res.path.must.eql(res.path2);
+      res.cost.must.equal(res2.cost);
+    });
+
     it('works with a more complicated graph', () => {
       const route = new Graph({
         a: { b: 7, c: 9, f: 14 },


### PR DESCRIPTION
I figured I'd take a shot at implementing #15. I'm no Node expert, nor did I dig very deep into the library, so this might be lacking or buggy. But it works for a simple test case modified from the readme:

```
const Graph = require('node-dijkstra')

const route = new Graph()

route.addNode('A', { B:1 })
route.addNode('B', { A:1, C:2, D: 4 })
route.addNode('C', { B:2, D:1 })
route.addNode('D', { C:1, B:4 })

route.path('A', 'D', {cost:true}) // => {path: [ 'A', 'B', 'C', 'D' ], cost: 4}

route.path('A', 'D', {cost:true, avoid:['C']}) // => {path: [ 'A', 'B', 'D' ], cost: 5}
```

A couple things I wasn't sure about:

1. Right now `avoid` must be an array -- should it also be alright to set it as a string (`{avoid: 'C'}`), for cases where only one node is to be avoided?

2. As it is, if you avoid the goal node the path always returns null, and if you avoid the start node it has no effect. Does this make sense, or should these throw errors, or behave in another way?